### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Include your project-specific ignores in this file
 # Read about how to use .gitignore: https://help.github.com/articles/ignoring-files
-dist
 bower_components
 node_modules
 npm-debug.log


### PR DESCRIPTION
Remove `dist` folder from `.gitignore`

Ignoring the `dist` folder would not be good since this is the location for any files processed via gulp.