### PR TITLE
Fixes watch and wiredep

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,10 +42,11 @@ var cssTasks = function(filename) {
     .pipe(function () {
       return $.if(mapsEnabled, $.sourcemaps.write('.'));
     })
-    .pipe(gulp.dest, path.dist + 'styles')();
+    .pipe(gulp.dest, path.dist + 'styles')
+    .pipe($.livereload)();
 };
 
-gulp.task('styles', ['wiredep'], function() {
+gulp.task('styles', function() {
   var merged = merge();
   manifest.forEachDependency('css', function (dep) {
     merged.add(gulp.src(dep.globs)
@@ -76,7 +77,8 @@ var jsTasks = function(filename) {
     .pipe(function () {
       return $.if(mapsEnabled, $.sourcemaps.write('.'));
     })
-    .pipe(gulp.dest, path.dist + 'scripts')();
+    .pipe(gulp.dest, path.dist + 'scripts')
+    .pipe($.livereload)();
 };
 
 gulp.task('scripts', ['jshint'], function() {
@@ -130,8 +132,9 @@ gulp.task('build', ['styles', 'scripts', 'fonts', 'images'], function() {
 
 gulp.task('wiredep', function() {
   var wiredep = require('wiredep').stream;
-  gulp.src(project.css)
+  return gulp.src(project.css)
     .pipe(wiredep())
+    .pipe($.changed(path.source + 'styles'))
     .pipe(gulp.dest(path.source + 'styles'));
 });
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "asset-builder": "~0.3.0",
     "del": "^1.1.1",
     "gulp": "^3.8.10",
+    "gulp-changed": "^1.1.0",
     "gulp-concat": "^2.3.4",
     "gulp-flatten": "0.0.4",
     "gulp-if": "^1.2.5",


### PR DESCRIPTION
wiredep now only touches your files if the destination file is different
from the source file

There were a couple issues such as the wiredep task not returning a stream and a couple race conditions.