### PR TITLE
Improve Google Analytics conditional loading

### DIFF
--- a/lib/assets.php
+++ b/lib/assets.php
@@ -84,23 +84,25 @@ add_action('wp_head', __NAMESPACE__ . '\\jquery_local_fallback');
  *
  * Cookie domain is 'auto' configured. See: http://goo.gl/VUCHKM
  */
-function google_analytics() { ?>
-<script>
-  <?php if (WP_ENV === 'production') : ?>
-    (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
-    function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
-    e=o.createElement(i);r=o.getElementsByTagName(i)[0];
-    e.src='//www.google-analytics.com/analytics.js';
-    r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-  <?php else : ?>
-    function ga() {
-      console.log('GoogleAnalytics: ' + [].slice.call(arguments));
-    }
-  <?php endif; ?>
-  ga('create','<?= GOOGLE_ANALYTICS_ID; ?>','auto');ga('send','pageview');
-</script>
+function google_analytics() {
+  ?>
+  <script>
+    <?php if (WP_ENV === 'production' && !current_user_can('manage_options')) : ?>
+      (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
+      function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
+      e=o.createElement(i);r=o.getElementsByTagName(i)[0];
+      e.src='//www.google-analytics.com/analytics.js';
+      r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
+    <?php else: ?>
+      function ga() {
+        console.log('Google Analytics: ' + [].slice.call(arguments));
+      }
+    <?php endif; ?>
+    ga('create','<?= GOOGLE_ANALYTICS_ID; ?>','auto');ga('send','pageview');
+  </script>
+  <?php
+}
 
-<?php }
-if (GOOGLE_ANALYTICS_ID && (WP_ENV !== 'production' || !current_user_can('manage_options'))) {
+if (GOOGLE_ANALYTICS_ID) {
   add_action('wp_footer', __NAMESPACE__ . '\\google_analytics', 20);
 }


### PR DESCRIPTION
The current logic for condtionally including the GA snippet is confusing (see #1232, #1188 and [here](http://discourse.roots.io/t/google-analytics-condition-seems-off/2778/4)) and bit inconsistent. In development you would see logging when the snippet wasn't included but this wouldn't happen if you were a logged in admin.

Now there's only two cases:

1. Production non admin user: GA snippet is loaded.
2. Anything else (development or admin user): log output