### PR TITLE
remove lodash from gulpfile and package.json

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,6 @@
 // ## Globals
 /*global $:true*/
 var $           = require('gulp-load-plugins')();
-var _           = require('lodash');
 var argv        = require('yargs').argv;
 var browserSync = require('browser-sync');
 var gulp        = require('gulp');

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "imagemin-pngcrush": "^4.0.0",
     "jshint-stylish": "^1.0.0",
     "lazypipe": "^0.2.2",
-    "lodash": "^2.4.1",
     "merge-stream": "^0.1.7",
     "traverse": "^0.6.6",
     "wiredep": "^2.1.0",


### PR DESCRIPTION
Speaking with @austinpray, lodash is not needed anymore. 