### PR TITLE
Fix node-sass and npm cache on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 sudo: false
 language: php
-cache: npm
+cache:
+  directories:
+  - node_modules
 php:
 - '5.6'
 - '5.5'
 - '5.4'
 
 before_install:
+  - npm cache clean
+  - npm prune
   - npm install -g bower gulp jscs
-  - npm install
+  - npm update
   - pyrus install pear/PHP_CodeSniffer
   - phpenv rehash
 


### PR DESCRIPTION
`cache: npm` isn't even a valid config anyway

https://stackoverflow.com/questions/15393821/npm-err-cb-never-called/15483897#15483897
https://github.com/sass/node-sass/issues/638