### PR TITLE
Fixes browsersync hard refresh

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -122,7 +122,9 @@ var jsTasks = function(filename) {
 var writeToManifest = function(directory) {
   return lazypipe()
     .pipe(gulp.dest, path.dist + directory)
-    .pipe(browserSync.reload, {stream:true})
+    .pipe(function() {
+      return $.if('**/*.{js,css}', browserSync.reload({stream:true}));
+    })
     .pipe($.rev.manifest, revManifest, {
       base: path.dist,
       merge: true


### PR DESCRIPTION
Whitelists js and css and does not send maps to browsersync.

ref: https://github.com/roots/roots/issues/1287#issuecomment-72085636
ref: http://discourse.roots.io/t/gulpfile-with-browsersync/2834/2