### PR TITLE
Uniform wp_link_pages between posts and pages

### DIFF
--- a/templates/content-page.php
+++ b/templates/content-page.php
@@ -1,2 +1,2 @@
 <?php the_content(); ?>
-<?php wp_link_pages(['before' => '<nav class="pagination">', 'after' => '</nav>']); ?>
+<?php wp_link_pages(['before' => '<nav class="page-nav"><p>' . __('Pages:', 'sage'), 'after' => '</p></nav>']); ?>


### PR DESCRIPTION
wp_link_pages is now included in posts and pages with the same structure. Removed Bootstrap class.