### PR TITLE
[8.0.0] reconcile bower dependency versions with CDN url

### DIFF
--- a/lib/assets.php
+++ b/lib/assets.php
@@ -38,7 +38,6 @@ function asset_path($filename) {
   $dist_path = get_template_directory_uri() . '/dist/';
   $directory = dirname($filename) . '/';
   $file = basename($filename);
-
   static $manifest;
 
   if (empty($manifest)) {
@@ -54,6 +53,31 @@ function asset_path($filename) {
   }
 }
 
+function bower_map_to_cdn($dependency, $fallback) {
+  static $bower;
+
+  if (empty($bower)) {
+    $bower_path = get_template_directory() . '/bower.json';
+    $bower = new JsonManifest($bower_path);
+    $bower = $bower->get();
+  }
+
+  $templates = [
+    'google' => '//ajax.googleapis.com/ajax/libs/%name%/%version%/%file%'
+  ];
+
+  $version = $bower['dependencies'][$dependency['name']];
+
+  if (isset($version) && preg_match('/^(\d+\.){2}\d+$/', $version)) {
+    $search = ['%name%', '%version%', '%file%'];
+    $replace = [$dependency['name'], $version, $dependency['file']];
+    return str_replace($search, $replace, $templates[$dependency['cdn']]);
+  } else {
+    return $fallback;
+  }
+
+}
+
 function assets() {
   wp_enqueue_style('sage_css', asset_path('styles/main.css'), false, null);
 
@@ -66,7 +90,11 @@ function assets() {
   if (!is_admin() && current_theme_supports('jquery-cdn')) {
     wp_deregister_script('jquery');
 
-    wp_register_script('jquery', '//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js', [], null, true);
+    wp_register_script('jquery', bower_map_to_cdn([
+      'name' => 'jquery',
+      'cdn' => 'google',
+      'file' => 'jquery.min.js'
+    ], asset_path('scripts/jquery.js')), [], null, true);
 
     add_filter('script_loader_src', __NAMESPACE__ . '\\jquery_local_fallback', 10, 2);
   }

--- a/lib/assets.php
+++ b/lib/assets.php
@@ -17,17 +17,34 @@ namespace Roots\Sage\Assets;
  * - An ID has been defined in config.php
  * - You're not logged in as an administrator
  */
+
+class JsonManifest {
+  private $manifest;
+
+  public function __construct($manifest_path) {
+    if (file_exists($manifest_path)) {
+      $this->manifest = json_decode(file_get_contents($manifest_path), true);
+    } else {
+      $this->manifest = [];
+    }
+  }
+
+  public function get() {
+    return $this->manifest;
+  }
+}
+
 function asset_path($filename) {
   $dist_path = get_template_directory_uri() . '/dist/';
   $directory = dirname($filename) . '/';
   $file = basename($filename);
 
-  $manifest_path = get_template_directory() . '/dist/assets.json';
+  static $manifest;
 
-  if (file_exists($manifest_path)) {
-    $manifest = json_decode(file_get_contents($manifest_path), true);
-  } else {
-    $manifest = [];
+  if (empty($manifest)) {
+    $manifest_path = get_template_directory() . '/dist/assets.json';
+    $manifest = new JsonManifest($manifest_path);
+    $manifest = $manifest->get();
   }
 
   if (WP_ENV !== 'development' && array_key_exists($file, $manifest)) {


### PR DESCRIPTION
- [x] memoize json reading
- [x] parse bower.json

## part 1

Memoize asset_path function

Previously roots would do a file operation each time asset_path is
called. So if you enqueued modernizr, jquery, and main.js it would read and parse dist/assets.json three times. Now it will only parse the json manifest one time per program execution.

Extract json reading to class that can be used to read bower.json

## part 2

fix https://github.com/roots/roots/issues/1286