### PR TITLE
Added wp-admin pages to browserSync ignore path.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -205,7 +205,10 @@ gulp.task('clean', require('del').bind(null, [path.dist]));
 // See: http://www.browsersync.io
 gulp.task('watch', function() {
   browserSync({
-    proxy: config.devUrl
+    proxy: config.devUrl,
+    snippetOptions: {
+      ignorePaths: 'wp-admin/**'
+    }
   });
   gulp.watch([path.source + 'styles/**/*'], ['styles']);
   gulp.watch([path.source + 'scripts/**/*'], ['jshint', 'scripts']);


### PR DESCRIPTION
Code from https://github.com/roots/roots/issues/1298#issuecomment-72369925
Closes https://github.com/roots/roots/issues/1298