### PR TITLE
Remove /**/* glob from js by default

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "main.js": {
       "files": [
-        "scripts/**/*",
         "scripts/main.js"
       ],
       "main": true


### PR DESCRIPTION
See https://discourse.roots.io/t/adding-none-bower-js-libs-to-gulp-manifest-json/2890?u=austin