### PR TITLE
Disable removeUnknownsAndDefaults on svgo

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -177,7 +177,8 @@ gulp.task('images', function() {
   return gulp.src(globs.images)
     .pipe($.imagemin({
       progressive: true,
-      interlaced: true
+      interlaced: true,
+      svgoPlugins: [{removeUnknownsAndDefaults: false}]
     }))
     .pipe(gulp.dest(path.dist + 'images'));
 });


### PR DESCRIPTION
because otherwise you'll occassionally run into broken SVG images