### PR TITLE
use correct editor-style.css filename for tinymce editor

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -2,6 +2,8 @@
 
 namespace Roots\Sage\Init;
 
+use Roots\Sage\Assets;
+
 /**
  * Theme setup
  */
@@ -35,7 +37,7 @@ function setup() {
   add_theme_support('html5', ['caption', 'comment-form', 'comment-list']);
 
   // Tell the TinyMCE editor to use a custom stylesheet
-  add_editor_style('dist/styles/editor-style.css');
+  add_editor_style(Assets\asset_path('styles/editor-style.css'));
 }
 add_action('after_setup_theme', __NAMESPACE__ . '\\setup');
 


### PR DESCRIPTION
This fixes the admin side editor to use theme styles.

