### PR TITLE
Migrate @Foxaii's nav-rejig for 8.0.0

### DIFF
--- a/lib/nav.php
+++ b/lib/nav.php
@@ -2,6 +2,8 @@
 
 namespace Roots\Sage\Nav;
 
+use Roots\Sage\Utils;
+
 /**
  * Cleaner walker for wp_nav_menu()
  *
@@ -14,6 +16,17 @@ namespace Roots\Sage\Nav;
  *   <li class="menu-sample-page"><a href="/sample-page/">Sample Page</a></li>
  */
 class SageNavWalker extends \Walker_Nav_Menu {
+  private $cpt; // Boolean, is current post a custom post type
+  private $archive; // Stores the archive page for current URL
+
+  public function __construct() {
+    add_filter('nav_menu_css_class', array($this, 'cssClasses'), 10, 2);
+    add_filter('nav_menu_item_id', '__return_null');
+    $cpt           = get_post_type();
+    $this->cpt     = in_array($cpt, get_post_types(array('_builtin' => false)));
+    $this->archive = get_post_type_archive_link($cpt);
+  }
+
   public function checkCurrent($classes) {
     return preg_match('/(current[-_])|active|dropdown/', $classes);
   }
@@ -45,48 +58,54 @@ class SageNavWalker extends \Walker_Nav_Menu {
 
     if ($element->is_dropdown) {
       $element->classes[] = 'dropdown';
+
+      foreach ($children_elements[$element->ID] as $child) {
+        if ($child->current_item_parent || Utils\url_compare($this->archive, $child->url)) {
+          $element->classes[] = 'active';
+        }
+      }
+    }
+
+    $element->is_active = strpos($this->archive, $element->url);
+
+    if ($element->is_active) {
+      $element->classes[] = 'active';
     }
 
     parent::display_element($element, $children_elements, $max_depth, $depth, $args, $output);
   }
   // @codingStandardsIgnoreEnd
+
+  public function cssClasses($classes, $item) {
+    $slug = sanitize_title($item->title);
+
+    if ($this->cpt) {
+      $classes = str_replace('current_page_parent', '', $classes);
+
+      if (Utils\url_compare($this->archive, $item->url)) {
+        $classes[] = 'active';
+      }
+    }
+
+    $classes = preg_replace('/(current(-menu-|[-_]page[-_])(item|parent|ancestor))/', 'active', $classes);
+    $classes = preg_replace('/^((menu|page)[-_\w+]+)+/', '', $classes);
+
+    $classes[] = 'menu-' . $slug;
+
+    $classes = array_unique($classes);
+
+    return array_filter($classes, 'Roots\\Sage\\Utils\\is_element_empty');
+  }
 }
-
-/**
- * Check if element is empty
- */
-function is_element_empty($element) {
-  $element = trim($element);
-  return !empty($element);
-}
-
-/**
- * Remove the id="" on nav menu items
- * Return 'menu-slug' for nav menu classes
- */
-function nav_menu_css_class($classes, $item) {
-  $slug = sanitize_title($item->title);
-  $classes = preg_replace('/(current(-menu-|[-_]page[-_])(item|parent|ancestor))/', 'active', $classes);
-  $classes = preg_replace('/^((menu|page)[-_\w+]+)+/', '', $classes);
-
-  $classes[] = 'menu-' . $slug;
-
-  $classes = array_unique($classes);
-
-  return array_filter($classes, __NAMESPACE__ . '\\is_element_empty');
-}
-add_filter('nav_menu_css_class', __NAMESPACE__ . '\\nav_menu_css_class', 10, 2);
-add_filter('nav_menu_item_id', '__return_null');
 
 /**
  * Clean up wp_nav_menu_args
  *
  * Remove the container
- * Use SageNavWalker() by default
+ * Remove the id="" on nav menu items
  */
 function nav_menu_args($args = '') {
   $nav_menu_args = [];
-
   $nav_menu_args['container'] = false;
 
   if (!$args['items_wrap']) {
@@ -100,3 +119,4 @@ function nav_menu_args($args = '') {
   return array_merge($args, $nav_menu_args);
 }
 add_filter('wp_nav_menu_args', __NAMESPACE__ . '\\nav_menu_args');
+add_filter('nav_menu_item_id', '__return_null');

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -24,3 +24,38 @@ function body_class($classes) {
   return $classes;
 }
 add_filter('body_class', __NAMESPACE__ . '\\body_class');
+
+/**
+ * Make a URL relative
+ */
+function root_relative_url($input) {
+  preg_match('|https?://([^/]+)(/.*)|i', $input, $matches);
+  if (!isset($matches[1]) || !isset($matches[2])) {
+    return $input;
+  } elseif (($matches[1] === $_SERVER['SERVER_NAME']) || $matches[1] === $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT']) {
+    return wp_make_link_relative($input);
+  } else {
+    return $input;
+  }
+}
+
+/**
+ * Compare URL against relative URL
+ */
+function url_compare($url, $rel) {
+  $url = trailingslashit($url);
+  $rel = trailingslashit($rel);
+  if ((strcasecmp($url, $rel) === 0) || root_relative_url($url) == $rel) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+/**
+ * Check if element is empty
+ */
+function is_element_empty($element) {
+  $element = trim($element);
+  return !empty($element);
+}


### PR DESCRIPTION
what @Foxaii's nav-rejig does:

* fixes the default WordPress functionality where your blog/posts page is shown as **active** when viewing a single CPT post
* marks the proper menu item as active when necessary for CPT archives and CPTs

needs a code review and possible cleanup before merge 