### PR TITLE
Fix missing `msgstr` in roots.pot

### DIFF
--- a/lang/roots.pot
+++ b/lang/roots.pot
@@ -1,4 +1,5 @@
 msgid ""
+msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 


### PR DESCRIPTION
`msgid` and `msgstr` may have to be set.

http://www.gnu.org/software/gettext/manual/gettext.html#PO-Files