### PR TITLE
Fix missing "msgstr" in .POT

### DIFF
--- a/lang/sage.pot
+++ b/lang/sage.pot
@@ -1,4 +1,5 @@
 msgid ""
+msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 


### PR DESCRIPTION
`msgid` and `msgstr` should always be in pairs.

http://www.gnu.org/software/gettext/manual/gettext.html#PO-Files